### PR TITLE
Run regression tests on a ZC702 FPGA board

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,7 @@ steps:
       pip install pytest
       pip install -e .
       pytest emu/test_emu_build.py
+      pytest emu/test_emu_prog.py
       deactivate
     label: "test_emu"
     timeout_in_minutes: 60

--- a/dragonphy/vivado_batch.py
+++ b/dragonphy/vivado_batch.py
@@ -14,6 +14,6 @@ def vivado_batch(script=None, cwd=None):
     args += ['-mode', 'batch']
     args += ['-source', f'{script}']
 
-    err_str = ['CRITICAL WARNING', 'ERROR', 'FATAL']
+    err_str = ['ERROR', 'FATAL']
 
     deluxe_run(args, cwd=cwd, err_strs=err_str)

--- a/dragonphy/vivado_tcl.py
+++ b/dragonphy/vivado_tcl.py
@@ -27,7 +27,7 @@ class VivadoTCL:
         self.proc = spawnu(command=cmd, cwd=cwd)
 
         # wait for the prompt
-        self.expect_prompt(timeout=30)
+        self.expect_prompt(timeout=300)
 
     def expect_prompt(self, timeout=float('inf')):
         before = ''

--- a/dragonphy/vivado_tcl.py
+++ b/dragonphy/vivado_tcl.py
@@ -11,7 +11,7 @@ class VivadoTCL:
     def __init__(self, cwd=None, prompt='Vivado% ', err_strs=None, debug=False):
         # set defaults
         if err_strs is None:
-            err_strs = ['ERROR', 'CRITICAL WARNING', 'FATAL']
+            err_strs = ['ERROR', 'FATAL']
 
         # save settings
         self.cwd = cwd

--- a/emu/build.tcl
+++ b/emu/build.tcl
@@ -1,5 +1,7 @@
 # Create the Vivado project
-create_project -force project project -part "xc7z020clg400-1"
+# ZC702: xc7z020clg484-1
+# PYNQ: xc7z020clg400-1
+create_project -force project project -part "xc7z020clg484-1"
 
 # Add source files
 add_files $file_list
@@ -12,9 +14,12 @@ add_files -fileset constrs_1 [glob "../emu/constr.xdc"]
 set_property -name top -value fpga_top -objects [current_fileset]
 
 # Instantiate the clock wizard
+# ZC702: Differential 200 MHz
+# PYNQ: Singled-ended 125 MHz
 create_ip -name clk_wiz -vendor xilinx.com -library ip -module_name clk_wiz_0
 set_property -dict [list \
-    CONFIG.PRIM_IN_FREQ 125.0 \
+    CONFIG.PRIM_SOURCE Differential_clock_capable_pin \
+    CONFIG.PRIM_IN_FREQ 200.0 \
     CONFIG.NUM_OUT_CLKS 2 \
     CONFIG.CLKOUT1_USED true \
     CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 20.0 \

--- a/emu/constr.xdc
+++ b/emu/constr.xdc
@@ -1,6 +1,13 @@
 # External clock
-set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { ext_clk }];
-create_clock -add -name ext_clk -period 8.00 -waveform {0 4} [get_ports { ext_clk }];
+
+# ZC702: Differential 200 MHz clock
+set_property -dict { PACKAGE_PIN D18 IOSTANDARD LVDS_25 } [get_ports ext_clk_p]
+set_property -dict { PACKAGE_PIN C19 IOSTANDARD LVDS_25 } [get_ports ext_clk_n]
+create_clock -period 5.000 -name ext_clk_p -waveform {0.000 2.500} -add [get_ports ext_clk_p]
+
+# PYNQ: Singled-ended 125 MHz clock
+# set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { ext_clk }];
+# create_clock -add -name ext_clk -period 8.000 -waveform {0.000 4.000} [get_ports { ext_clk }];
 
 # Debug Hub Clock
 set_property C_ENABLE_CLK_DIVIDER false [get_debug_cores dbg_hub]

--- a/stim/fpga_stim.sv
+++ b/stim/fpga_stim.sv
@@ -1,15 +1,20 @@
 // dragon uses fpga_top
 
 module stim;
-    logic ext_clk;
+    logic ext_clk_p, ext_clk_n;
 
-    fpga_top fpga_top_i(.ext_clk(ext_clk));
+    fpga_top fpga_top_i(
+        .ext_clk_p(ext_clk_p),
+        .ext_clk_n(ext_clk_n)
+    );
 
     always begin
-        ext_clk = 1'b0;
-        #(0.5/125e6*1s);
-        ext_clk = 1'b1;
-        #(0.5/125e6*1s);
+        ext_clk_p = 1'b0;
+        ext_clk_n = 1'b1;
+        #(0.5/200e6*1s);
+        ext_clk_p = 1'b1;
+        ext_clk_n = 1'b0;
+        #(0.5/200e6*1s);
     end
 
     initial begin

--- a/verif/fpga_top.sv
+++ b/verif/fpga_top.sv
@@ -3,7 +3,8 @@
 `include "signals.sv"
 
 module fpga_top(
-    input wire logic ext_clk
+    input wire logic ext_clk_p,
+    input wire logic ext_clk_n
 );
 
 //////////////////////////////
@@ -22,7 +23,8 @@ emu_if emu ();
 ////////////////////////////////////
 logic emu_clk_2x;
 mmcm mmcm_i (
-    .ext_clk(ext_clk),
+    .ext_clk_p(ext_clk_p),
+    .ext_clk_n(ext_clk_n),
     .emu_clk_2x(emu_clk_2x)
 );
 

--- a/verif/mmcm/fpga/mmcm.sv
+++ b/verif/mmcm/fpga/mmcm.sv
@@ -11,7 +11,7 @@ module mmcm (
         .clk_out2(dbg_clk),
         .reset(0),
         .locked(locked),
-        .clk_in1_p(ext_clk_p)
+        .clk_in1_p(ext_clk_p),
         .clk_in1_n(ext_clk_n)
     );
 

--- a/verif/mmcm/fpga/mmcm.sv
+++ b/verif/mmcm/fpga/mmcm.sv
@@ -1,5 +1,6 @@
 module mmcm (
-    input wire logic ext_clk,
+    input wire logic ext_clk_p,
+    input wire logic ext_clk_n,
     output var logic emu_clk_2x
 );
 
@@ -10,7 +11,8 @@ module mmcm (
         .clk_out2(dbg_clk),
         .reset(0),
         .locked(locked),
-        .clk_in1(ext_clk)
+        .clk_in1_p(ext_clk_p)
+        .clk_in1_n(ext_clk_n)
     );
 
 endmodule

--- a/verif/mmcm/fpga_verif/mmcm.sv
+++ b/verif/mmcm/fpga_verif/mmcm.sv
@@ -1,7 +1,8 @@
 module mmcm #(
     parameter real freq=20e6
 ) (
-    input wire logic ext_clk,
+    input wire logic ext_clk_p,
+    input wire logic ext_clk_n,
     output var logic emu_clk_2x
 );
 


### PR DESCRIPTION
This PR adds regression testing on physical FPGA boards to the set to tests performed upon checkin to the repository.  This adds less than a minute to the regression test flow because we have already been checking that the FPGA bitstream builds successfully.  The FPGA boards used are ZC702 and we currently have two identical setups in our server room.