### PR TITLE
Add debug capabilities to loopback test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,7 +19,7 @@ steps:
 
       # run tests
       pip install pytest
-      pytest tests
+      pytest tests -xs
     label: "test"
     timeout_in_minutes: 60
     agents:
@@ -40,7 +40,7 @@ steps:
       pip install pytest
 
       # build bitstream
-      pytest emu/test_emu_build.py
+      pytest emu/test_emu_build.py -xs
 
       # show results of bitstream build
       tree emu
@@ -48,7 +48,7 @@ steps:
       cat emu/build/project/project.runs/impl_1/runme.log
 
       # program FPGA and run test
-      pytest emu/test_emu_prog.py
+      pytest emu/test_emu_prog.py -xs
 
       # deactivate virtual env
       deactivate

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,8 +44,8 @@ steps:
 
       # show results of bitstream build
       tree emu
-      cat emu/build/project/project.runs/synth_1/runme.log
-      cat emu/build/project/project.runs/impl_1/runme.log
+      cat emu/project/project.runs/synth_1/runme.log
+      cat emu/project/project.runs/impl_1/runme.log
 
       # program FPGA and run test
       pytest emu/test_emu_prog.py -xs

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,23 @@
 steps:
   - command: |
+      # set up environment
       export PATH=$$PATH:/usr/local/miniconda/bin:/usr/local/bin
       echo $$PATH
       export LD_LIBRARY_PATH=$$LD_LIBRARY_PATH:/usr/local/lib
       echo $$LD_LIBRARY_PATH
+
+      # tool setup
       source /cad/modules/tcl/init/bash
-      module load base
-      module load xcelium
+      module load base xcelium
+
+      # create conda env
       conda create -p ./conda_env -m -y pip python=3.7.4
       export PATH=$$PWD/conda_env/bin:$$PATH
+
+      # install dragonphy
       pip install -e .
+
+      # run tests
       pip install pytest
       pytest tests
     label: "test"
@@ -17,14 +25,32 @@ steps:
     agents:
       butterphy: "true"
   - command: |
+      # set up environment
       source /etc/environment
       echo $$PATH
+
+      # activate virtual env
       python3.7 -m venv venv
       source venv/bin/activate
-      pip install pytest
+
+      # install dragonphy
       pip install -e .
+
+      # install pytest to allow tests to run
+      pip install pytest
+
+      # build bitstream
       pytest emu/test_emu_build.py
+
+      # show results of bitstream build
+      tree emu
+      cat emu/build/project/project.runs/synth_1/runme.log
+      cat emu/build/project/project.runs/impl_1/runme.log
+
+      # program FPGA and run test
       pytest emu/test_emu_prog.py
+
+      # deactivate virtual env
       deactivate
     label: "test_emu"
     timeout_in_minutes: 60

--- a/dragonphy/vivado_tcl.py
+++ b/dragonphy/vivado_tcl.py
@@ -22,7 +22,7 @@ class VivadoTCL:
 
         # return at this point if in "mock" mode
         if self.mock:
-            print('Creating a VivadoTCL object is "mock" mode.')
+            print('Creating a VivadoTCL object in "mock" mode.')
             return
 
         # start the interpreter

--- a/dragonphy/vivado_tcl.py
+++ b/dragonphy/vivado_tcl.py
@@ -8,7 +8,7 @@ from .console_print import cprint_block, cprint_block_start, cprint_block_end
 SERVER_PORT = 57937
 
 class VivadoTCL:
-    def __init__(self, cwd=None, prompt='Vivado% ', err_strs=None, debug=False):
+    def __init__(self, cwd=None, prompt='Vivado% ', err_strs=None, debug=False, mock=False):
         # set defaults
         if err_strs is None:
             err_strs = ['ERROR', 'FATAL']
@@ -18,6 +18,12 @@ class VivadoTCL:
         self.prompt = prompt
         self.debug = debug
         self.err_strs = err_strs
+        self.mock = mock
+
+        # return at this point if in "mock" mode
+        if self.mock:
+            print('Creating a VivadoTCL object is "mock" mode.')
+            return
 
         # start the interpreter
         from pexpect import spawnu
@@ -25,7 +31,7 @@ class VivadoTCL:
         sys.stdout.flush()
         cmd = 'vivado -nolog -nojournal -notrace -mode tcl'
         self.proc = spawnu(command=cmd, cwd=cwd)
-
+        
         # wait for the prompt
         self.expect_prompt(timeout=300)
 
@@ -53,6 +59,10 @@ class VivadoTCL:
         return before
 
     def sendline(self, line, timeout=float('inf')):
+        if self.mock:
+            print(f'Would send the TCL command "{line}".')
+            return
+
         if self.debug:
             cprint_block([line], title='SEND', color='magenta')
 
@@ -67,19 +77,35 @@ class VivadoTCL:
         return before
 
     def source(self, script, timeout=float('inf')):
+        if self.mock:
+            print(f'Would source the TCL script {script}.')
+            return
+
         script = Path(script).resolve()
         self.sendline(f'source {script}', timeout=timeout)
     
     def refresh_hw_vio(self, name, timeout=30):
+        if self.mock:
+            print(f'Would refresh the VIO to get the latest signal values.')
+            return
+
         self.sendline(f'refresh_hw_vio {name}', timeout=timeout)
 
     def get_vio(self, name, timeout=30):
+        if self.mock:
+            print(f'Would get VIO signal {name}, but will just return 0 for now.')
+            return 0
+
         before = self.sendline(f'get_property INPUT_VALUE {name}', timeout=timeout)
         before = before.splitlines()[-1] # get last line
         before = before.strip() # strip off whitespace
         return before
 
     def set_vio(self, name, value, timeout=30):
+        if self.mock:
+            print(f'Would set VIO signal {name} to value {value}.')
+            return
+
         self.sendline(f'set_property OUTPUT_VALUE {value} {name}', timeout=timeout)
         self.sendline(f'commit_hw_vio {name}')
 
@@ -100,6 +126,9 @@ class VivadoTCL:
             raise Exception(f"Don't know how to convert to a TCL literal: {value}.")
 
     def __del__(self):
+        if self.mock:
+            return
+
         print('Sending "exit" to Vivado TCL interpreter.')
         self.proc.sendline('exit')
 

--- a/emu/build.tcl
+++ b/emu/build.tcl
@@ -30,13 +30,17 @@ set_property -dict [list \
 # Create the VIO
 create_ip -name vio -vendor xilinx.com -library ip -module_name vio_0
 set_property -dict [list \
-    CONFIG.C_NUM_PROBE_IN 1 \
-    CONFIG.C_NUM_PROBE_OUT 2 \
-    CONFIG.C_PROBE_IN0_WIDTH 64 \
+    CONFIG.C_NUM_PROBE_IN 3 \
+    CONFIG.C_NUM_PROBE_OUT 3 \
+    CONFIG.C_PROBE_IN0_WIDTH 8 \
+    CONFIG.C_PROBE_IN1_WIDTH 64 \
+    CONFIG.C_PROBE_IN2_WIDTH 64 \
     CONFIG.C_PROBE_OUT0_WIDTH 1 \
     CONFIG.C_PROBE_OUT0_INIT_VAL 0x1 \
     CONFIG.C_PROBE_OUT1_WIDTH 1 \
     CONFIG.C_PROBE_OUT1_INIT_VAL 0x1 \
+    CONFIG.C_PROBE_OUT2_WIDTH 2 \
+    CONFIG.C_PROBE_OUT2_INIT_VAL 0x0 \
 ] [get_ips vio_0]
 
 # Generate IP targets

--- a/emu/build.tcl
+++ b/emu/build.tcl
@@ -31,7 +31,7 @@ set_property -dict [list \
 create_ip -name vio -vendor xilinx.com -library ip -module_name vio_0
 set_property -dict [list \
     CONFIG.C_NUM_PROBE_IN 3 \
-    CONFIG.C_NUM_PROBE_OUT 3 \
+    CONFIG.C_NUM_PROBE_OUT 4 \
     CONFIG.C_PROBE_IN0_WIDTH 8 \
     CONFIG.C_PROBE_IN1_WIDTH 64 \
     CONFIG.C_PROBE_IN2_WIDTH 64 \
@@ -41,6 +41,8 @@ set_property -dict [list \
     CONFIG.C_PROBE_OUT1_INIT_VAL 0x1 \
     CONFIG.C_PROBE_OUT2_WIDTH 2 \
     CONFIG.C_PROBE_OUT2_INIT_VAL 0x0 \
+    CONFIG.C_PROBE_OUT3_WIDTH 32 \
+    CONFIG.C_PROBE_OUT3_INIT_VAL 0xFFFFFFFF \
 ] [get_ips vio_0]
 
 # Generate IP targets

--- a/emu/program.tcl
+++ b/emu/program.tcl
@@ -25,8 +25,11 @@ set_property CORE_REFRESH_RATE_MS 0 $vio_0_i
 
 # set aliases to VIO probes
 set emu_rst [get_hw_probes "vio_i/emu_rst" -of_objects $vio_0_i]
-set rst_user [get_hw_probes "vio_i/rst_user" -of_objects $vio_0_i]
-set number [get_hw_probes "vio_i/number" -of_objects $vio_0_i]
+set prbs_rst [get_hw_probes "vio_i/prbs_rst" -of_objects $vio_0_i]
+set lb_mode [get_hw_probes "vio_i/lb_mode" -of_objects $vio_0_i]
+set lb_latency [get_hw_probes "vio_i/lb_latency" -of_objects $vio_0_i]
+set lb_correct_bits [get_hw_probes "vio_i/lb_correct_bits" -of_objects $vio_0_i]
+set lb_total_bits [get_hw_probes "vio_i/lb_total_bits" -of_objects $vio_0_i]
 
 # configure VIO radix
 set_property INPUT_VALUE_RADIX UNSIGNED $number

--- a/emu/program.tcl
+++ b/emu/program.tcl
@@ -26,6 +26,7 @@ set_property CORE_REFRESH_RATE_MS 0 $vio_0_i
 # set aliases to VIO probes
 set emu_rst [get_hw_probes "vio_i/emu_rst" -of_objects $vio_0_i]
 set prbs_rst [get_hw_probes "vio_i/prbs_rst" -of_objects $vio_0_i]
+set tm_stall [get_hw_probes "vio_i/tm_stall" -of_objects $vio_0_i]
 set lb_mode [get_hw_probes "vio_i/lb_mode" -of_objects $vio_0_i]
 set lb_latency [get_hw_probes "vio_i/lb_latency" -of_objects $vio_0_i]
 set lb_correct_bits [get_hw_probes "vio_i/lb_correct_bits" -of_objects $vio_0_i]

--- a/emu/program.tcl
+++ b/emu/program.tcl
@@ -32,4 +32,6 @@ set lb_correct_bits [get_hw_probes "vio_i/lb_correct_bits" -of_objects $vio_0_i]
 set lb_total_bits [get_hw_probes "vio_i/lb_total_bits" -of_objects $vio_0_i]
 
 # configure VIO radix
-set_property INPUT_VALUE_RADIX UNSIGNED $number
+set_property INPUT_VALUE_RADIX UNSIGNED $lb_latency
+set_property INPUT_VALUE_RADIX UNSIGNED $lb_correct_bits
+set_property INPUT_VALUE_RADIX UNSIGNED $lb_total_bits

--- a/emu/test_emu_prog.py
+++ b/emu/test_emu_prog.py
@@ -12,20 +12,23 @@ def test_emu_prog(mock=False):
 
     # reset emulator
     tcl.set_vio(name='$emu_rst', value=0b1)
-    sleep(1e-6)
+    sleep(0.1)
     tcl.set_vio(name='$emu_rst', value=0b0)
-    sleep(1e-6)
+    sleep(0.1)
     # reset everything else
     tcl.set_vio(name='$prbs_rst', value=0b1)
     tcl.set_vio(name='$lb_mode', value=0b00)
-    sleep(1e-6)
+    sleep(0.1)
     # align the loopback tester
     tcl.set_vio(name='$prbs_rst', value=0b0)
     tcl.set_vio(name='$lb_mode', value=0b01)
-    sleep(100e-6)
+    sleep(1)
     # run the loopback test
     tcl.set_vio(name='$lb_mode', value=0b10)
-    sleep(1.1)
+    sleep(10.1)
+    # halt the emulation
+    tcl.set_vio(name='$tm_stall', value=0x00000000)
+    sleep(0.1)
     # get results
     print(f'Reading results from VIO.')
     tcl.refresh_hw_vio('$vio_0_i')
@@ -37,7 +40,7 @@ def test_emu_prog(mock=False):
     print(f'Loopback correct bits: {lb_correct_bits}.')
     print(f'Loopback total bits: {lb_total_bits}.')
     # check results
-    assert (lb_total_bits >= 5e6), 'Not enough total bits transmitted.'
+    assert (lb_total_bits >= 50e6), 'Not enough total bits transmitted.'
     assert (lb_total_bits == lb_correct_bits), 'Bit error detected.'
 
 if __name__ == '__main__':

--- a/emu/test_emu_prog.py
+++ b/emu/test_emu_prog.py
@@ -12,6 +12,7 @@ def test_emu_prog(mock=False):
 
     # reset emulator
     tcl.set_vio(name='$emu_rst', value=0b1)
+    tcl.set_vio(name='$tm_stall', value=0xffffffff)
     sleep(0.1)
     tcl.set_vio(name='$emu_rst', value=0b0)
     sleep(0.1)

--- a/emu/test_emu_prog.py
+++ b/emu/test_emu_prog.py
@@ -25,7 +25,7 @@ def test_emu_prog(mock=False):
     sleep(100e-6)
     # run the loopback test
     tcl.set_vio(name='$lb_mode', value=0b10)
-    sleep(2100e-6)
+    sleep(1.1)
     # get results
     print(f'Reading results from VIO.')
     tcl.refresh_hw_vio('$vio_0_i')
@@ -37,7 +37,7 @@ def test_emu_prog(mock=False):
     print(f'Loopback correct bits: {lb_correct_bits}.')
     print(f'Loopback total bits: {lb_total_bits}.')
     # check results
-    assert (lb_total_bits >= 10000), 'Not enough total bits transmitted.'
+    assert (lb_total_bits >= 5e6), 'Not enough total bits transmitted.'
     assert (lb_total_bits == lb_correct_bits), 'Bit error detected.'
 
 if __name__ == '__main__':

--- a/emu/test_emu_prog.py
+++ b/emu/test_emu_prog.py
@@ -12,7 +12,7 @@ def test_emu_prog(mock=False):
 
     # reset emulator
     tcl.set_vio(name='$emu_rst', value=0b1)
-    tcl.set_vio(name='$tm_stall', value=0xffffffff)
+    tcl.set_vio(name='$tm_stall', value='FFFFFFFF')
     sleep(0.1)
     tcl.set_vio(name='$emu_rst', value=0b0)
     sleep(0.1)
@@ -28,7 +28,7 @@ def test_emu_prog(mock=False):
     tcl.set_vio(name='$lb_mode', value=0b10)
     sleep(10.1)
     # halt the emulation
-    tcl.set_vio(name='$tm_stall', value=0x00000000)
+    tcl.set_vio(name='$tm_stall', value='00000000')
     sleep(0.1)
     # get results
     print(f'Reading results from VIO.')

--- a/emu/test_emu_prog.py
+++ b/emu/test_emu_prog.py
@@ -2,9 +2,9 @@ from time import sleep
 from dragonphy import *
 
 
-def test_emu_prog(emu_rate=5e6, sleep_time=1):
+def test_emu_prog(mock=False):
     # start TCL interpreter
-    tcl = VivadoTCL(cwd=get_dir('emu'), debug=True)
+    tcl = VivadoTCL(cwd=get_dir('emu'), debug=True, mock=mock)
 
     # program FPGA
     print('Programming FPGA.')
@@ -41,4 +41,4 @@ def test_emu_prog(emu_rate=5e6, sleep_time=1):
     assert (lb_total_bits == lb_correct_bits), 'Bit error detected.'
 
 if __name__ == '__main__':
-    test_emu_prog()
+    test_emu_prog(mock=True)

--- a/stim/fpga_stim.sv
+++ b/stim/fpga_stim.sv
@@ -18,15 +18,31 @@ module stim;
     end
 
     initial begin
+        // reset emulator
         force fpga_top_i.emu.rst = 1'b1;
-        force fpga_top_i.tb_i.rst_user = 1'b1;
-        #(3us);
+        #(1us);
         force fpga_top_i.emu.rst = 1'b0;
-        #(3us);
-        force fpga_top_i.tb_i.rst_user = 1'b0; 
+        #(1us);
+        // reset everything else
+        force fpga_top_i.tb_i.prbs_rst = 1'b1;
+        force fpga_top_i.tb_i.lb_mode = 2'b00;
+        #(1us);
+        // align the loopback tester
+        force fpga_top_i.tb_i.prbs_rst = 1'b0;
+        force fpga_top_i.tb_i.lb_mode = 2'b01;
         #(100us);
-        assert (fpga_top_i.tb_i.number >= 400) else
-            $error("Not enough successful bits.");
+        // run the loopback test
+        force fpga_top_i.tb_i.lb_mode = 2'b10;
+        #(2100us);
+        // print results
+        $display("Loopback latency: %0d cycles.", fpga_top_i.tb_i.lb_latency);
+        $display("Loopback correct bits: %0d.", fpga_top_i.tb_i.lb_correct_bits);
+        $display("Loopback total bits: %0d.", fpga_top_i.tb_i.lb_total_bits);
+        // check results
+        assert (fpga_top_i.tb_i.lb_total_bits >= 10000) else
+            $error("Not enough total bits transmitted.");
+        assert (fpga_top_i.tb_i.lb_total_bits == fpga_top_i.tb_i.lb_correct_bits) else
+            $error("Bit error detected.");
         $finish;
     end
 endmodule

--- a/stim/loopback_stim.sv
+++ b/stim/loopback_stim.sv
@@ -3,14 +3,28 @@
 module stim;
 
     tb tb_i();
-    
+
     initial begin
-        force tb_i.rst_user = 1'b1;
+        // reset everything
+        force tb_i.prbs_rst = 1'b1;
+        force tb_i.lb_mode = 2'b00;
         #(20ns);
-        force tb_i.rst_user = 1'b0; 
+        // align the loopback tester
+        force tb_i.prbs_rst = 1'b0;
+        force tb_i.lb_mode = 2'b01;
         #(2500ns);
-        assert (tb_i.number >= 1000) else
-            $error("Not enough successful bits.");
+        // run the loopback test
+        force tb_i.lb_mode = 2'b10;
+        #(21000ns);
+        // print results
+        $display("Loopback latency: %0d cycles.", tb_i.lb_latency);
+        $display("Loopback correct bits: %0d.", tb_i.lb_correct_bits);
+        $display("Loopback total bits: %0d.", tb_i.lb_total_bits);
+        // check results
+        assert (tb_i.lb_total_bits >= 10000) else
+            $error("Not enough total bits transmitted.");
+        assert (tb_i.lb_total_bits == tb_i.lb_correct_bits) else
+            $error("Bit error detected.");
         $finish;
     end
 

--- a/verif/fpga_top.sv
+++ b/verif/fpga_top.sv
@@ -50,7 +50,7 @@ assign tb_i.tx_clk_i.clk_i = clks[1];
 ///////////////////////////////////
 // generate the emulation timestep
 ///////////////////////////////////
-localparam integer n_dt = 2;
+localparam integer n_dt = 3;
 dt_t dt_req [n_dt];
 time_manager  #(.n(n_dt)) tm_i (
     .dt_req(dt_req),
@@ -60,6 +60,9 @@ time_manager  #(.n(n_dt)) tm_i (
 assign dt_req[0] = tb_i.rx_i.rx_clk_i.dt_req;
 // TX
 assign dt_req[1] = tb_i.tx_clk_i.dt_req;
+// Stall signal
+dt_t tm_stall;
+assign dt_req[2] = tm_stall;
 
 /////////////////////////////////
 // Read/Write signals externally
@@ -67,6 +70,7 @@ assign dt_req[1] = tb_i.tx_clk_i.dt_req;
 vio vio_i (
     .emu_rst(emu.rst),
     .prbs_rst(tb_i.prbs_rst),
+    .tm_stall(tm_stall),
     .lb_mode(tb_i.lb_mode),
     .lb_latency(tb_i.lb_latency),
     .lb_total_bits(tb_i.lb_total_bits),

--- a/verif/fpga_top.sv
+++ b/verif/fpga_top.sv
@@ -66,8 +66,11 @@ assign dt_req[1] = tb_i.tx_clk_i.dt_req;
 /////////////////////////////////
 vio vio_i (
     .emu_rst(emu.rst),
-    .rst_user(tb_i.rst_user),
-    .number(tb_i.number),
+    .prbs_rst(tb_i.prbs_rst),
+    .lb_mode(tb_i.lb_mode),
+    .lb_latency(tb_i.lb_latency),
+    .lb_total_bits(tb_i.lb_total_bits),
+    .lb_correct_bits(tb_i.lb_correct_bits),
     .clk(emu.clk)
 );
 

--- a/verif/loopback.sv
+++ b/verif/loopback.sv
@@ -1,27 +1,33 @@
 `include "signals.sv"
 
 module loopback #(
-    parameter integer n_addr=5
+    parameter integer n_addr=8
 ) (
     input wire logic data_tx,
     input wire logic clk_tx,
-    input wire logic rst_tx,
     input wire logic data_rx,
     input wire logic clk_rx,
-    input wire logic rst_rx,
-    output var logic [63:0] number
+    input wire logic [1:0] mode,
+    output var logic [63:0] correct_bits,
+    output var logic [63:0] total_bits,
+    output wire logic [(n_addr-1):0] latency
 );
+
+    // TODO: consider using enum here
+    localparam logic [1:0] RESET = 2'b00;
+    localparam logic [1:0] ALIGN = 2'b01;
+    localparam logic [1:0]  TEST = 2'b10;
 
     // memory for previously transmitted bits
     logic mem [2**n_addr];
 
     // record TX data
-    logic [n_addr-1:0] ptr_tx;
+    logic [(n_addr-1):0] ptr_tx;
     always @(posedge clk_tx) begin
         mem[ptr_tx] <= data_tx;
     end
     always @(posedge clk_tx) begin
-        if (rst_tx) begin
+        if (mode == RESET) begin
             ptr_tx <= 0;
         end else begin
 	        ptr_tx <= ptr_tx + 1;
@@ -29,22 +35,36 @@ module loopback #(
     end
 
     // check the RX data
-    logic [n_addr-1:0] ptr_rx = 0;
+    logic [(n_addr-1):0] ptr_rx;
     logic mem_rd;
     always @(posedge clk_rx) begin
         mem_rd <= mem[ptr_rx];
     end
     always @(posedge clk_rx) begin
-        if (rst_rx) begin
+        if (mode == RESET) begin
             ptr_rx <= 0;
-            number <= 64'd0;
-        end else if (data_rx == mem_rd) begin
-	        ptr_rx <= ptr_rx + 1;
-            number <= number + 64'd1;
+            correct_bits <= 64'd0;
+            total_bits <= 64'd0;
+        end else if (mode == ALIGN) begin
+            if (data_rx == mem_rd) begin
+	            ptr_rx <= ptr_rx + 1;
+            end else begin
+	            ptr_rx <= ptr_rx;
+            end
+            correct_bits <= 64'd0;
+            total_bits <= 64'd0;
         end else begin
-	        ptr_rx <= ptr_rx;
-            number <= 64'd0;
+            if (data_rx == mem_rd) begin
+                correct_bits <= correct_bits + 64'd1;
+            end else begin
+                correct_bits <= correct_bits;
+            end
+            ptr_rx <= ptr_rx + 1;
+            total_bits <= total_bits + 64'd1;
         end
     end
+
+    // send latency value to the output
+    assign latency = ptr_tx - ptr_rx;
 
 endmodule

--- a/verif/tb.sv
+++ b/verif/tb.sv
@@ -7,10 +7,17 @@ module tb;
     `DECL_ANALOG(data_tx_o);
     `DECL_ANALOG(data_rx_i);
 
-    logic rst_user;
     logic clk_tx_i, data_tx_i;
     logic data_rx_o, clk_rx_o;
-    logic [63:0] number;
+
+    // prbs signals
+    logic prbs_rst;
+
+    // loopback tester signals
+    logic [1:0] lb_mode;
+    logic [7:0] lb_latency;
+    logic [63:0] lb_correct_bits;
+    logic [63:0] lb_total_bits;
 
     // transmitter
     tx tx_i (
@@ -41,18 +48,19 @@ module tb;
     prbs21 prbs21_i (
 	    .out_o(data_tx_i),
         .clk_i(clk_tx_i),
-        .rst_i(rst_user)
+        .rst_i(prbs_rst)
     );
 
     // loopback tester
     loopback lb_i (
         .data_tx(data_tx_i),
         .clk_tx(clk_tx_i),
-        .rst_tx(rst_user),
         .data_rx(data_rx_o),
         .clk_rx(clk_rx_o),
-        .rst_rx(rst_user),
-        .number(number)
+        .mode(lb_mode),
+        .correct_bits(lb_correct_bits),
+        .total_bits(lb_total_bits),
+        .latency(lb_latency)
     );
 
 endmodule

--- a/verif/vio/fpga/vio.sv
+++ b/verif/vio/fpga/vio.sv
@@ -1,15 +1,21 @@
 module vio (
     output wire logic emu_rst,
-    output wire logic rst_user,
-    input wire logic [63:0] number,
+    output wire logic prbs_rst,
+    output wire logic [1:0] lb_mode,
+    input wire logic [7:0] lb_latency,
+    input wire logic [63:0] lb_correct_bits,
+    input wire logic [63:0] lb_total_bits,
     input wire logic clk
 );
 
     vio_0 vio_0_i (
         .clk(clk),
-        .probe_in0(number),
+        .probe_in0(lb_latency),
+        .probe_in1(lb_correct_bits),
+        .probe_in2(lb_total_bits),
         .probe_out0(emu_rst),
-        .probe_out1(rst_user)
+        .probe_out1(prbs_rst),
+        .probe_out2(lb_mode)
     );
 
 endmodule

--- a/verif/vio/fpga/vio.sv
+++ b/verif/vio/fpga/vio.sv
@@ -2,6 +2,7 @@ module vio (
     output wire logic emu_rst,
     output wire logic prbs_rst,
     output wire logic [1:0] lb_mode,
+    output wire logic [31:0] tm_stall,
     input wire logic [7:0] lb_latency,
     input wire logic [63:0] lb_correct_bits,
     input wire logic [63:0] lb_total_bits,
@@ -15,7 +16,8 @@ module vio (
         .probe_in2(lb_total_bits),
         .probe_out0(emu_rst),
         .probe_out1(prbs_rst),
-        .probe_out2(lb_mode)
+        .probe_out2(lb_mode),
+        .probe_out3(tm_stall)
     );
 
 endmodule

--- a/verif/vio/fpga_verif/vio.sv
+++ b/verif/vio/fpga_verif/vio.sv
@@ -1,7 +1,10 @@
 module vio (
     output wire logic emu_rst,
-    output wire logic rst_user,
-    input wire logic [63:0] number,
+    output wire logic prbs_rst,
+    output wire logic [1:0] lb_mode,
+    input wire logic [7:0] lb_latency,
+    input wire logic [63:0] lb_correct_bits,
+    input wire logic [63:0] lb_total_bits,
     input wire logic clk
 );
 

--- a/verif/vio/fpga_verif/vio.sv
+++ b/verif/vio/fpga_verif/vio.sv
@@ -2,6 +2,7 @@ module vio (
     output wire logic emu_rst,
     output wire logic prbs_rst,
     output wire logic [1:0] lb_mode,
+    output wire logic [31:0] tm_stall,
     input wire logic [7:0] lb_latency,
     input wire logic [63:0] lb_correct_bits,
     input wire logic [63:0] lb_total_bits,


### PR DESCRIPTION
This PR introduces several new features to the loopback test to aid in debugging:
1. The loopback test now produces three outputs:
    1. Total number of bits transmitted.
    2. Number of bits correctly received.
    3. Estimated latency (in cycles) from the transmitter input to the receiver output.
2. Changed the loopback tester behavior so that there are three distinct phases:
    1. RESET: the loopback read/writer pointers are reset to 0
    2. ALIGN: TX bits are streamed into memory while the loopback tester adjusts the position of the read pointer be aligned with the TX -> RX latency.
    3. TEST: The TX -> RX latency is frozen and the total number of bits is tracked, in addition to the number of bits correctly received.
3. Added the capability to freeze the emulation to ensure that all outputs are read simultaneously (via the **tm_stall** signal).  This allows the user to assert that the number of correct bits is exactly equal to the total number of bits transmitted.
4. FPGA synthesis and implementation logs are printed out in BuildKite

The last update is that the total number of bits checked has been increased to 50M from 5M.

Sample output from emulation:
```shell
Loopback latency: 4 cycles.
Loopback correct bits: 51083003.
Loopback total bits: 51083003.
```
