### PR TITLE
lock pip versions of emulation tools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
                 'generator', 'ic', 'integrated circuit', 'chip'],
     packages=find_packages(),
     install_requires=[
-        'svreal>=0.2.0.dev1',
-        'msdsl>=0.1.6',
-        'anasymod>=0.1.9',
+        'svreal==0.2.0.dev1',
+        'msdsl==0.1.6',
+        'anasymod==0.1.9',
         'pexpect', 
         'pyyaml',
         'numpy',


### PR DESCRIPTION
The master branch broke since setup.py specified ">=" vs "==" in setup.py for anasymod / msdsl / svreal.  While these packages are in development, I think we should use "==" for repeatable build results, since breaking changes are possible in those three projects.